### PR TITLE
Get the correct type of originator_id when building versions for update_all

### DIFF
--- a/lib/paper_trail/repo_client.ex
+++ b/lib/paper_trail/repo_client.ex
@@ -13,6 +13,9 @@ defmodule PaperTrail.RepoClient do
   @spec originator :: PaperTrail.originator()
   def originator, do: Application.get_env(:paper_trail, :originator, nil)
 
+  @spec originator_type :: atom()
+  def originator_type, do: Application.get_env(:paper_trail, :originator_type, :integer)
+
   @spec strict_mode(PaperTrail.options()) :: PaperTrail.strict_mode()
   def strict_mode(options \\ []) do
     case Keyword.get(options, :strict_mode) do

--- a/lib/paper_trail/serializer.ex
+++ b/lib/paper_trail/serializer.ex
@@ -78,6 +78,7 @@ defmodule PaperTrail.Serializer do
     originator = RepoClient.originator()
     originator_ref = options[originator[:name]] || options[:originator]
     originator_id = if(originator_ref, do: originator_ref.id, else: nil)
+    originator_id_type = RepoClient.originator_type()
     origin = options[:origin]
     meta = options[:meta]
     repo = RepoClient.repo(options)
@@ -89,7 +90,7 @@ defmodule PaperTrail.Serializer do
           item_type: type(^item_type, :string),
           item_id: field(q, ^primary_key),
           item_changes: type(^changes_map, :map),
-          originator_id: type(^originator_id, :string),
+          originator_id: type(^originator_id, ^originator_id_type),
           origin: type(^origin, :string),
           meta: type(^meta, :map),
           inserted_at: type(fragment("CURRENT_TIMESTAMP"), :naive_datetime)

--- a/lib/version.ex
+++ b/lib/version.ex
@@ -4,10 +4,6 @@ defmodule PaperTrail.Version do
   import Ecto.Changeset
   import Ecto.Query
 
-  # @setter PaperTrail.RepoClient.originator()
-  # @item_type Application.get_env(:paper_trail, :item_type, :integer)
-  # @originator_type Application.get_env(:paper_trail, :originator_type, :integer)
-
   @type t :: %__MODULE__{
           event: String.t(),
           item_type: String.t(),
@@ -22,7 +18,7 @@ defmodule PaperTrail.Version do
     field(:item_type, :string)
     field(:item_id, Application.get_env(:paper_trail, :item_type, :integer))
     field(:item_changes, :map)
-    field(:originator_id, Application.get_env(:paper_trail, :originator_type, :integer))
+    field(:originator_id, PaperTrail.RepoClient.originator_type())
 
     field(:origin, :string,
       read_after_writes: Application.get_env(:paper_trail, :origin_read_after_writes, true)
@@ -36,7 +32,7 @@ defmodule PaperTrail.Version do
         PaperTrail.RepoClient.originator()[:model],
         define_field: false,
         foreign_key: :originator_id,
-        type: Application.get_env(:paper_trail, :originator_type, :integer)
+        type: PaperTrail.RepoClient.originator_type()
       )
     end
 


### PR DESCRIPTION
When setting the originator on `update_all`, the following error is happening because the `originator_type` is an integer:

```
(Ecto.Query.CastError) project/deps/paper_trail/lib/paper_trail/serializer.ex:86: value `5177` in `select` cannot be cast to type :string in query
```

